### PR TITLE
fix: update end date for Customer Facing role at Wolfram

### DIFF
--- a/inputs/cv_conor_cosnett.yaml
+++ b/inputs/cv_conor_cosnett.yaml
@@ -41,7 +41,7 @@ sections:
           logo: /logo_toptal.png
           label: Customer Facing Mathematica Programmer - Wolfram Research
           startdate: June 2022
-          enddate: March 2023
+          enddate: March 2024
         points:
           - "Solved over 1200 complex math and programming problems for clients including Boeing, the US Navy, Raytheon, and renowned physicists, e.g. Andrew J. Hanson."
           - "Acted as the team’s subject matter expert for the OpenAI API integration into Mathematica, solving over 200 cases in this area."


### PR DESCRIPTION
Fix the end date for the "Customer Facing Mathematica Programmer - Wolfram Research" role from March 2023 to March 2024.

Closes #11

Generated with [Claude Code](https://claude.ai/code)