### PR TITLE
Fix end date for Compass Labs role to November 2025

### DIFF
--- a/inputs/cv_conor_cosnett.yaml
+++ b/inputs/cv_conor_cosnett.yaml
@@ -20,7 +20,7 @@ sections:
           logo: /logo_compass.png
           label: Founding Engineer - Compass Labs Ltd
           startdate: October 2024
-          enddate: Present
+          enddate: November 2025
         points:
           - "Founding engineer at an Andreessen Horowitz - backed DeFi infrastructure startup."
           - "Delivered over 1000 GitHub contributions in 11 months, including to the <a href=\"https://github.com/langchain-ai/langchain/pull/30794/commits/\"><u>LangChain repo.</u></a>"


### PR DESCRIPTION
Changed the end date for the latest role (Founding Engineer - Compass Labs) from `Present` to `November 2025`.

Closes #12

Generated with [Claude Code](https://claude.ai/code)